### PR TITLE
make cppcheck nonfatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
         submodules: true
         fetch-depth: 0
     - name: Perform Source Code checks that were successful in the past
+      continue-on-error: true
       run: |
         set -x
         git fetch --recurse-submodules=no https://github.com/linuxcnc/linuxcnc refs/tags/*:refs/tags/*


### PR DESCRIPTION
reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error